### PR TITLE
Refactor Discord integration to use bot only (remove webhooks)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -66,11 +66,14 @@
   "alert_email_to": "ALERT EMAIL HERE",
 
   "enable_discord": false,
-  "enable_discord_webhook": false,
-  "discord_webhook_url": "",
+  "discord_bot_token": "",
+  "discord_channel_id": "",
   "discord_send_emergency": false,
   "discord_send_ai": false,
   "discord_send_all": false,
+  "discord_receive_enabled": true,
+  "discord_inbound_channel_index": null,
+  "discord_response_channel_index": null,
   "discord_presence_status": "online",
   "discord_presence_activity": "Meshtastic-Controller Online"
 }


### PR DESCRIPTION
Changed Discord integration to use only the Discord bot for both sending and receiving messages, eliminating the need for webhooks.

Changes:
- Replaced webhook-based message sending with bot.send() using discord.py
- Removed poll_discord_channel() function in favor of on_message event handler
- Consolidated start_discord_presence() into start_discord_bot() that handles presence, sending, and receiving messages
- Removed DISCORD_WEBHOOK_URL and ENABLE_DISCORD_WEBHOOK configuration options
- Removed /discord_webhook Flask endpoint (no longer needed)
- Updated config.json to remove webhook settings
- Updated README.md documentation to reflect bot-only approach
- Added Message Content Intent requirement to troubleshooting section

Benefits:
- Simpler configuration (only bot token and channel ID needed)
- Real-time message receiving via events instead of polling
- Single Discord client handles all functionality
- Reduced dependencies on webhook infrastructure