### PR TITLE
Fix Discord-mesh bidirectional sync by adding missing global declaration

### DIFF
--- a/main.py
+++ b/main.py
@@ -542,7 +542,7 @@ def send_discord_message(content):
     """Send a message to Discord using the bot client."""
     if not (ENABLE_DISCORD and DISCORD_BOT_TOKEN and DISCORD_CHANNEL_ID):
         return
-    global discord_bot_channel
+    global discord_bot_channel, discord_bot_loop
     if discord_bot_channel is None:
         print("⚠️ Discord bot channel not ready yet")
         return


### PR DESCRIPTION
The send_discord_message() function was missing 'discord_bot_loop' in its global declaration, causing an UnboundLocalError when trying to send messages from the mesh to Discord. This bug prevented both directions of messaging:
- Mesh messages couldn't be sent to Discord (due to the missing global)
- As a result, the entire Discord integration appeared broken

Fixed by adding 'discord_bot_loop' to the global declaration on line 545.