### PR TITLE
Add 'hello' as AI keyword without slash prefix

### DIFF
--- a/config/commands_config.json
+++ b/config/commands_config.json
@@ -17,6 +17,10 @@
       "ai_prompt": "{user_input}"
     },
     {
+      "command": "hello",
+      "ai_prompt": "Respond to this greeting in a friendly way: {user_input}"
+    },
+    {
       "command": "/ping",
       "response": "Pong!"
     },


### PR DESCRIPTION
The 'hello' keyword now works without a slash prefix to trigger an AI response, matching the behavior of other keywords like 'ai', 'bot', 'query', and 'data'. The existing '/hello' slash command remains unchanged for backward compatibility.

Fixes: Hello keyword not triggering AI response