### PR TITLE
Fix AI message routing by initializing missing variables

### DIFF
--- a/main.py
+++ b/main.py
@@ -261,6 +261,10 @@ lastChannelIndex = None
 discord_bot_channel = None
 discord_bot_loop = None
 
+# AI channel tracking globals
+active_ai_channels = {}  # Track which channels have AI enabled
+AI_CHANNEL_TIMEOUT = 3600  # AI channel auto-disable timeout in seconds (1 hour)
+
 # -----------------------------
 # Location Lookup Function
 # -----------------------------


### PR DESCRIPTION
The keyword detection wasn't working because two critical variables were undefined, causing the code to crash before reaching the keyword detection logic:

- active_ai_channels: Dictionary to track which channels have AI enabled
- AI_CHANNEL_TIMEOUT: Timeout constant for auto-disabling AI (set to 1 hour)

Keywords like 'ai', 'bot', 'query', 'data' now work without requiring the "/" prefix as configured in commands_config.json.

Fixes the following crashes:
- NameError at line 770: 'active_ai_channels' is not defined
- NameError at line 771: 'AI_CHANNEL_TIMEOUT' is not defined