### PR TITLE
Fix command matching to support both /command and command formats

### DIFF
--- a/main.py
+++ b/main.py
@@ -731,7 +731,11 @@ def handle_command(cmd, full_text, sender_id):
             print(f"⚠️ Failed to send SMS: {e}")
             return "Failed to send SMS."
     for c in commands_config.get("commands", []):
-        if c.get("command").lower() == cmd:
+        config_cmd = c.get("command", "").lower()
+        # Normalize both commands by removing leading '/' for comparison
+        normalized_cmd = cmd.lstrip('/')
+        normalized_config_cmd = config_cmd.lstrip('/')
+        if normalized_config_cmd == normalized_cmd:
             if "ai_prompt" in c:
                 user_input = full_text[len(cmd):].strip()
                 custom_text = c["ai_prompt"].replace("{user_input}", user_input)


### PR DESCRIPTION
Commands in commands_config.json without a leading "/" now work correctly when users prefix them with "/". The fix normalizes command comparison by stripping leading "/" from both the user's input and config commands before matching, allowing flexible command usage regardless of how they're defined in the config.